### PR TITLE
Create the Project Directory if it Doesn't Exist

### DIFF
--- a/project.new.kw.inc
+++ b/project.new.kw.inc
@@ -13,8 +13,15 @@
  *   Directory where to create the new project. Optional. Defaults to the 
  *   current working directory.
  */
-function drush_kraftwagen_kw_new_project($dir = NULL) {
-  $dir = realpath($dir ? $dir : getcwd());
+function drush_kraftwagen_kw_new_project($argdir = NULL) {
+  if (!file_exists(realpath(getcwd() . '/' . $argdir))){
+    drush_mkdir(getcwd() . '/' . $argdir);
+  }
+  $dir = realpath($argdir ? $argdir : getcwd());
+  if (!$dir) {
+    drush_log(dt('The directory !dir could not be created.', array('!dir' => './' . $argdir)), 'error');
+    return;
+  }
 
   // If the dir has a kraftwagenrc file, we should load it.
   if (file_exists($dir . DIRECTORY_SEPARATOR . KRAFTWAGEN_RC)) {


### PR DESCRIPTION
Attached code fixes this.

Without the fix, I get errors that indicate that krafwagen is trying to create the project in `/` because we concatenate `FALSE` with `'/src'` for the call to `drush_mkdir()`. When I create the directory beforehand, it works fine. See below.

```
Wills-MacBook-Pro:drupals $ ls -al
total 0
drwxr-xr-x    2 willmilton  staff    68 Mar 10 13:11 .
drwxr-xr-x+ 150 willmilton  staff  5100 Mar 10 13:25 ..
Wills-MacBook-Pro:drupals $ drush kw-np krafty
Enter the human readable name of the project []: krafty
Enter the internal machine name of the project [krafty]:
Enter the location of the skeleton repository: https://github.com/kraftwagen/skeleton
Enter the name of the branch to use [source repository HEAD]:
Directory / exists, but is not writable. Please check directory     [error]
permissions.
file_put_contents(/src/.gitignore): failed to open stream: No such  [warning]
file or directory kraftwagen.fileutils.inc:39
Directory / exists, but is not writable. Please check directory     [error]
permissions.
file_put_contents(/src/cnf/settings.local.php): failed to open      [warning]
stream: No such file or directory kraftwagen.fileutils.inc:39
file_put_contents(/src/cnf/settings.php): failed to open stream: No [warning]
such file or directory kraftwagen.fileutils.inc:39
Directory / exists, but is not writable. Please check directory     [error]
permissions.
Directory / exists, but is not writable. Please check directory     [error]
permissions.
file_put_contents(/src/modules/contrib/README.md): failed to open   [warning]
stream: No such file or directory kraftwagen.fileutils.inc:39
Directory / exists, but is not writable. Please check directory     [error]
permissions.
file_put_contents(/src/modules/custom/README.md): failed to open    [warning]
stream: No such file or directory kraftwagen.fileutils.inc:39
Directory / exists, but is not writable. Please check directory     [error]
permissions.
file_put_contents(/src/modules/features/README.md): failed to open  [warning]
stream: No such file or directory kraftwagen.fileutils.inc:39
Directory / exists, but is not writable. Please check directory     [error]
permissions.
file_put_contents(/src/modules/kraftwagen/README.md): failed to open[warning]
stream: No such file or directory kraftwagen.fileutils.inc:39
file_put_contents(/src/modules/README.md): failed to open stream: No[warning]
such file or directory kraftwagen.fileutils.inc:39
file_put_contents(/src/README.md): failed to open stream: No such   [warning]
file or directory kraftwagen.fileutils.inc:39
file_put_contents(/src/krafty.info): failed to open stream: No such [warning]
file or directory kraftwagen.fileutils.inc:39
file_put_contents(/src/krafty.install): failed to open stream: No   [warning]
such file or directory kraftwagen.fileutils.inc:39
file_put_contents(/src/krafty.make): failed to open stream: No such [warning]
file or directory kraftwagen.fileutils.inc:39
file_put_contents(/src/krafty.profile): failed to open stream: No   [warning]
such file or directory kraftwagen.fileutils.inc:39
Directory / exists, but is not writable. Please check directory     [error]
permissions.
Directory / exists, but is not writable. Please check directory     [error]
permissions.
file_put_contents(/src/themes/basic/basic.info): failed to open     [warning]
stream: No such file or directory kraftwagen.fileutils.inc:39
file_put_contents(/src/themes/basic/layout.css): failed to open     [warning]
stream: No such file or directory kraftwagen.fileutils.inc:39
file_put_contents(/src/themes/basic/logo.png): failed to open       [warning]
stream: No such file or directory kraftwagen.fileutils.inc:39
file_put_contents(/src/themes/basic/README.md): failed to open      [warning]
stream: No such file or directory kraftwagen.fileutils.inc:39
file_put_contents(/src/themes/basic/screenshot.png): failed to open [warning]
stream: No such file or directory kraftwagen.fileutils.inc:39
file_put_contents(/src/themes/basic/template.php): failed to open   [warning]
stream: No such file or directory kraftwagen.fileutils.inc:39
file_put_contents(/src/themes/README.md): failed to open stream: No [warning]
such file or directory kraftwagen.fileutils.inc:39
Directory / exists, but is not writable. Please check directory     [error]
permissions.
file_put_contents(/src/tools/build.make.tpl): failed to open stream:[warning]
No such file or directory kraftwagen.fileutils.inc:39
Directory / exists, but is not writable. Please check directory     [error]
permissions.
file_put_contents(/src/translations/README.md): failed to open      [warning]
stream: No such file or directory kraftwagen.fileutils.inc:39
Copied the project skeleton to your source directory.               [ok]
Wills-MacBook-Pro:drupals $ drush help kw-np
Create a new project. This will create an new source directory from a Git
skeleton repository.

Arguments:
 directory                                 The directory to create the project
                                           in. Defaults to the current
                                           directory


Options:
 --force                                   Forces execution of this command,
                                           even if the specified source dir
                                           already exists.


Aliases: kw-np
Wills-MacBook-Pro:drupals $ mkdir krafty
Wills-MacBook-Pro:drupals $ drush kw-np krafty
Enter the human readable name of the project [krafty]:
Enter the internal machine name of the project [krafty]:
Enter the location of the skeleton repository: https://github.com/kraftwagen/skeleton
Enter the name of the branch to use [source repository HEAD]:
Copied the project skeleton to your source directory.               [ok]
Wills-MacBook-Pro:drupals $

```
