### PR TITLE
symlink is destroyed after moving from tmp folder by drush.

### DIFF
--- a/process.make.inc
+++ b/process.make.inc
@@ -33,7 +33,15 @@ function make_download_kraftwagen_directory() {
  *  projects[***MACHINE_NAME***][download][type] = "kraftwagen_symlink"
  *  projects[***MACHINE_NAME***][download][url] = "**SRC_DIR**  ($target)
 */
-function make_download_kraftwagen_symlink($project, $target, $link_name) {
+function make_download_kraftwagen_symlink() {
+  $args = func_get_args();
+  $name = array_shift($args);
+  if (count($args) > 2) {
+    $type = array_shift($args);
+  }
+  $target = array_shift($args);
+  $link_name = array_shift($args);
+
   // Symlinks cannot be created on Windows OS.
   if (drush_is_windows()) {
     return drush_set_error('DRUSH_IS_WINDOWS', dt("Symlinks cannot be created on Windows platform."));


### PR DESCRIPTION
This code is about: https://github.com/kraftwagen/kraftwagen/issues/22

I just needed it sooner than I had expected and I coded what you said.

Unfortunately, it does not work because `drush` makes the symlink while the build is still on `/tmp`, and later when drush copy the instance to the installation folder, it is not a symlink anymore.

I created the Pull Request just in case you want to check it out.
Any suggestions are welcome.
