### PR TITLE
Allow use of options for kw-np, good for shell scripts.

### DIFF
--- a/kraftwagen.drush.inc
+++ b/kraftwagen.drush.inc
@@ -21,6 +21,10 @@ function kraftwagen_drush_command() {
     'aliases' => array('kw-np'),
     'options' => array(
       'force' => dt('Forces execution of this command, even if the specified source dir already exists.'),
+      'label' => dt('The human readable name of the project.'),
+      'name' => dt('The internal machine name of the project.'),
+      'skeleton' => dt('The location of the skeleton repository.'),
+      'branch' => dt('The name of the branch to use.'),
     ),
   );
 

--- a/project.new.kw.inc
+++ b/project.new.kw.inc
@@ -35,21 +35,33 @@ function drush_kraftwagen_kw_new_project($argdir = NULL) {
     return;
   }
 
-  // Ask for the human readable name of the project. This can be used for the
-  // name property of the install profile. Defaults to the name of the current
-  // directory.
-  $project_label = drush_prompt(dt('Enter the human readable name of the project'), basename($dir));
+  $project_label = drush_get_option('label');
+  if (!$project_label) {
+    // Ask for the human readable name of the project. This can be used for the
+    // name property of the install profile. Defaults to the name of the current
+    // directory.
+    $project_label = drush_prompt(dt('Enter the human readable name of the project'), basename($dir));
+  }
 
-  // Create machine name for the project. This defaults to a simplified version
-  // of the human readable name. This is used for the file names.
-  $project_name = _kraftwagen_drush_prompt_validate(
-    dt('Enter the internal machine name of the project'),
-    _kraftwagen_generate_name($project_label), TRUE, '_kraftwagen_validate_name'
-  );
+  $project_name = drush_get_option('name');
+  if (!$project_name) {
+    // Create machine name for the project. This defaults to a simplified version
+    // of the human readable name. This is used for the file names.
+    $project_name = _kraftwagen_drush_prompt_validate(
+      dt('Enter the internal machine name of the project'),
+      _kraftwagen_generate_name($project_label), TRUE, '_kraftwagen_validate_name'
+    );
+  }
 
-  // Ask for the location of the git repository that contains the skeleton.
-  $skeleton = drush_prompt(dt('Enter the location of the skeleton repository'), 'git://github.com/kraftwagen/skeleton.git');
-  $branch = drush_prompt(dt('Enter the name of the branch to use [source repository HEAD]'), NULL, FALSE);
+  $skeleton = drush_get_option('skeleton');
+  if (!$skeleton) {
+    // Ask for the location of the git repository that contains the skeleton.
+    $skeleton = drush_prompt(dt('Enter the location of the skeleton repository'), 'git://github.com/kraftwagen/skeleton.git');
+  }
+  $branch = drush_get_option('branch');
+  if (!$branch) {
+    $branch = drush_prompt(dt('Enter the name of the branch to use [source repository HEAD]'), NULL, FALSE);
+  }
 
   // Create a tempdir where we are going to clone the repository in.
   $tempdir = drush_tempdir();


### PR DESCRIPTION
This will allow the use of argument options for `kw-np`
New options:
- label
- name
- skeleton
- branch

example: `drush kw-np my_directory --label=my_label`
This is useful for writing other shell scripts which may call Kraftwagen