### PR TITLE
Fix support kw-update-makefile for drush 7.x+

### DIFF
--- a/kraftwagen.drush.inc
+++ b/kraftwagen.drush.inc
@@ -63,6 +63,13 @@ function kraftwagen_drush_command() {
     ),
     'required-arguments' => 1,
     'aliases' => array('kw-um'),
+    'engines' => array(
+      'release_info',
+    ),
+    'options' => array(
+      'security-only'  => 'Only update modules that have security updates available.',
+      'make-update-default-url' => 'The default location to load the XML update information from.',
+    ),
   );
 
   $items['kw-update'] = array(

--- a/makefile.update.kw.inc
+++ b/makefile.update.kw.inc
@@ -16,12 +16,9 @@ function drush_kraftwagen_kw_update_makefile($makefile) {
   require_once dirname(__FILE__) . '/includes/kraftwagen.info_files.inc';
 
   $info = kraftwagen_read_info_file($makefile);
-  if (version_compare(drush_core_version(), '7', '>=')) {
-    $update_info = kraftwagen_update_projects78($info);
-  }
-  else {
-    $update_info = kraftwagen_update_projects($info);
-  }
+  $update_info = (version_compare(drush_core_version(), '7', '>='))
+    ? kraftwagen_update_projects78($info) : kraftwagen_update_projects($info);
+
   if (empty($update_info)) {
     drush_log(dt('No updates required.'), 'success');
     return;

--- a/makefile.update.kw.inc
+++ b/makefile.update.kw.inc
@@ -16,7 +16,7 @@ function drush_kraftwagen_kw_update_makefile($makefile) {
   require_once dirname(__FILE__) . '/includes/kraftwagen.info_files.inc';
 
   $info = kraftwagen_read_info_file($makefile);
-  if (version_compare(drush_core_version(), '6', '>')) {
+  if (version_compare(drush_core_version(), '7', '>=')) {
     $update_info = kraftwagen_update_projects78($info);
   }
   else {

--- a/makefile.update.kw.inc
+++ b/makefile.update.kw.inc
@@ -5,10 +5,10 @@
  * This file contains the functions that are required to execute
  * `drush kw-update-makefile`.
  */
-
+use Drush\UpdateService\ReleaseInfo;
 /**
  * Implements drush_COMMAND() for `drush kw-update-makefile`.
- * 
+ *
  * @param string $location
  *   The location of the make file to be updated.
  */
@@ -16,8 +16,12 @@ function drush_kraftwagen_kw_update_makefile($makefile) {
   require_once dirname(__FILE__) . '/includes/kraftwagen.info_files.inc';
 
   $info = kraftwagen_read_info_file($makefile);
-  $update_info = kraftwagen_update_projects($info);
-
+  if (version_compare(drush_core_version(), '6', '>')) {
+    $update_info = kraftwagen_update_projects78($info);
+  }
+  else {
+    $update_info = kraftwagen_update_projects($info);
+  }
   if (empty($update_info)) {
     drush_log(dt('No updates required.'), 'success');
     return;
@@ -28,6 +32,64 @@ function drush_kraftwagen_kw_update_makefile($makefile) {
   }
 
   drush_log(dt('Updated !makefile.', array('!makefile' => $makefile)), 'success');
+}
+
+/**
+ * Reads a makefile for projects and returns the updated versions. For drush 7+.
+ *
+ * @param array $info
+ *   The make file info array
+ *
+ * @return array
+ *   The update info
+ */
+function kraftwagen_update_projects78($info) {
+  $release_info = drush_get_engine('release_info');
+
+  foreach($info['projects'] as $project_name => $project) {
+    if (isset($project['download'])) {
+      drush_log(dt('Project !project is downloaded explicitly instead of normal contrib or core behavior. We will not try to update this.', array('!project' => $project_name)), 'ok');
+      continue;
+    }
+
+    // Projects without a version specified are serious upgrade risk.
+    if (empty($project) || empty($project['version'])) {
+      drush_log(dt('No version specified for project !project. This can lead to unintended upgrades.', array('!project' => $project_name)), 'warning');
+      // Don't try to determine a better version.
+      continue;
+    }
+
+    // Projects with just a major version specified are theoretically a smaller
+    // risk, but should still be avoided.
+    $exploded_version = explode('.', $project['version']);
+    if (count($exploded_version) < 2) {
+      drush_log(dt('Only a major version specified for project !project. This can lead to unintended upgrades.', array('!project' => $project_name)), 'warning');
+      // Don't try to determine a better version.
+      continue;
+    }
+    $full_projectname = $project_name . '-' . $info['core'] . '-' . $project['version'];
+
+    // Create a new project array that is suitable to pass into
+    // release_info_fetch.
+    $request = pm_parse_request($full_projectname, drush_get_option('make-update-default-url', ReleaseInfo::DEFAULT_URL));
+    if (!($project_data_retrieved = getAppropriateRelease($release_info, $request))) {
+      drush_log(dt('Project !project could not be found and was not updated'), array('!project' => $project_name), 'warning');
+      continue;
+    }
+
+    $version_string = $project_data_retrieved['version_major'] . '.' . $project_data_retrieved['version_patch'];
+    if (!empty($project_data_retrieved['version_extra'])) {
+      $version_string .= '-' . $project_data_retrieved['version_extra'];
+    }
+    if (version_compare($version_string, $project['version'], '>')) {
+      $update_info[$project_name] = array(
+        'current_version' => $info['projects'][$project_name]['version'],
+        'new_version' => $version_string
+      );
+    }
+  }
+
+  return $update_info;
 }
 
 /**
@@ -54,7 +116,7 @@ function kraftwagen_update_projects($info) {
     if (empty($project) || empty($project['version']) || $project['version'] == DRUSH_MAKE_VERSION_BEST) {
       drush_log(dt('No version specified for project !project. This can lead to unintended upgrades.', array('!project' => $project_name)), 'warning');
       // Don't try to determine a better version.
-      continue; 
+      continue;
     }
 
     // Projects with just a major version specified are theoretically a smaller
@@ -63,7 +125,7 @@ function kraftwagen_update_projects($info) {
     if (count($exploded_version) < 2) {
       drush_log(dt('Only a major version specified for project !project. This can lead to unintended upgrades.', array('!project' => $project_name)), 'warning');
       // Don't try to determine a better version.
-      continue; 
+      continue;
     }
 
     // Get major version.
@@ -106,14 +168,14 @@ function kraftwagen_update_makefile($makefile, $update_info) {
 
   foreach ($update_info as $project_name => $info) {
     $new_contents = preg_replace(
-      '/(' . preg_quote($project_name) . '[^\n]*\[version\][^\n]*)' . preg_quote($info['current_version']) . '/', 
+      '/(' . preg_quote($project_name) . '[^\n]*\[version\][^\n]*)' . preg_quote($info['current_version']) . '/',
       '${1}' . $info['new_version'],
       $contents
     );
 
     if ($new_contents == $contents) {
       $new_contents = preg_replace(
-        '/(' . preg_quote($project_name) . '[^\n]*[^\n]*)' . preg_quote($info['current_version']) . '/', 
+        '/(' . preg_quote($project_name) . '[^\n]*[^\n]*)' . preg_quote($info['current_version']) . '/',
         '${1}' . $info['new_version'],
         $contents
       );
@@ -128,4 +190,47 @@ function kraftwagen_update_makefile($makefile, $update_info) {
   file_put_contents($makefile, $contents);
 
   return TRUE;
+}
+
+/**
+ * Obtain the most appropiate release for the requested project.
+ *
+ * @return array|bool
+ *    The selected release xml object or FALSE.
+ */
+function getAppropriateRelease($release_info, $request) {
+  $project_release_info = $release_info->get($request);
+  if (!$project_release_info) {
+    return FALSE;
+  }
+
+  if (drush_get_option('security-only')) {
+    return getSecurityRelease($project_release_info);
+  }
+
+  // If there was no specific release requested, try to identify the most appropriate release.
+  return $project_release_info->getRecommendedOrSupportedRelease();
+}
+
+/**
+ * Pick the latest security release from XML list.
+ *
+ * @return array|bool
+ *    The selected release xml object or FALSE.
+ */
+function getSecurityRelease($release_info) {
+  $info = $release_info->getInfo();
+  $releases = $info['releases'];
+
+  if (!empty($releases)) {
+    foreach ($releases as $one_release) {
+      if (!empty($one_release['terms']['Release type'])
+        && in_array('Security update', $one_release['terms']['Release type'])) {
+
+        return $one_release;
+      }
+    }
+  }
+
+  return FALSE;
 }


### PR DESCRIPTION
Drush 7 changed its way of fetching updates; release_info_fetch() was removed. This caused php errors when using 'drush kw-update-makefile'. This problem is fixed in this pull request.
We've also added the 'security-only' and 'make-update-default-url' arguments.