### PR TITLE
feature/-working-copy-flag - Add working copy flag to kw-build

### DIFF
--- a/build.kw.inc
+++ b/build.kw.inc
@@ -24,6 +24,9 @@ function drush_kraftwagen_kw_build() {
   require_once dirname(__FILE__) . '/includes/kraftwagen.fileutils.inc';
   $make_file_location = drush_tempnam('kw');
 
+  // Check for the working-copy option.
+  $working_copy = drush_get_option(array('working-copy')) ? '1' : '0';
+
   // Gind out where to create the new build.
   if (!($target_dir = kraftwagen_build_determine_target($root))) {
     return drush_set_error(dt('Could not determine a build target.'));
@@ -32,6 +35,7 @@ function drush_kraftwagen_kw_build() {
   kraftwagen_commands_sequence_run('build-commands', array(
     '*make_file_location*' => $make_file_location,
     '*target_dir*' => $target_dir,
+    '*working_copy*' => $working_copy,
   ));
 }
 

--- a/kraftwagen.drush.inc
+++ b/kraftwagen.drush.inc
@@ -32,6 +32,9 @@ function kraftwagen_drush_command() {
     'bootstrap' => DRUSH_BOOTSTRAP_DRUSH,
     'description' => dt('Create a build from the source'),
     'aliases' => array('kw-b'),
+    'options' => array(
+      'working-copy' => dt('Creates a working copy for the projects.'),
+    )
   );
 
   $items['kw-generate-makefile'] = array(

--- a/kraftwagenrc.php
+++ b/kraftwagenrc.php
@@ -51,7 +51,7 @@ $options['root-checks'] = array(
 
 $options['build-commands'] = array(
   'kw-generate-makefile' => array('*make_file_location*'),
-  'make' => array('*make_file_location*', '*target_dir*','--concurrency=1'),
+  'make' => array('*make_file_location*', '*target_dir*', '--working-copy=*working_copy*', '--concurrency=1'),
   'kw-setup-symlinks' => array('*target_dir*'),
   'kw-activate-build' => array('*target_dir*'),
 );


### PR DESCRIPTION
Functionality to add the working-copy flag to the kw-build command. Developers can use the flag, so they can easily push to the projects, build with the kw-build command. This flag adds the working-copy option from drush_make to every project in the makefile.